### PR TITLE
Monsagri/modernise integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ notes
 test.py
 .vscode
 .claude
+.venv

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 notes
 test.py
+.vscode
+.claude

--- a/README.md
+++ b/README.md
@@ -1,25 +1,36 @@
 # Eon Next
 
-This is a custom component for Home Assistant which integrates with the Eon Next API and gets all the meter readings from your accounts.
+Custom Home Assistant integration for E.ON Next accounts.
 
-A sensor will be created for each meter showing:
+## Features
 
-- The latest reading
-- The date the latest reading was taken
-
-For electric meters the readings are in kWh. For gas meter the readings are in m³.
-
-An additional sensor is created for gas meters showing the latest reading in kWh.
-
+- Latest meter reading and reading date sensors for electricity and gas.
+- Gas conversion sensor from m3 to kWh.
+- Daily consumption sensor with dual fallback:
+  - REST consumption endpoint first.
+  - `consumptionDataByMpxn` GraphQL fallback if REST is unavailable.
+- EV smart charging sensors (when SmartFlex devices are present):
+  - Smart charging schedule status.
+  - Next charge slot start/end.
+  - Second charge slot start/end.
+- Native HA re-auth flow:
+  - Authentication failures trigger Home Assistant's re-auth prompt.
+  - Password changes can be fixed from the standard UI flow.
+- Modern HA runtime pattern via `entry.runtime_data`.
 
 ## Installation
 
-Copy the `eon_next` folder to the `custom_components` folder inside your HA config directory. If a `custom_components` folder does not exist, just create it.
+1. Copy the `eon_next` folder into `custom_components` in your Home Assistant config directory.
+2. Restart Home Assistant.
+3. Go to **Settings -> Devices & Services -> Add Integration** and add **Eon Next**.
 
-Next restart Home Assistant.
+## HACS / Release
 
-Setting up this component is done entirely in the UI. Go to your Integration settings, press to add a new integration, and find "Eon Next".
+The integration manifest and `hacs.json` are versioned for HACS compatibility.
 
-The setup wizard will ask you to enter your account login details, and that is all there is too it!
+For a HACS-visible release, create and push a semantic version tag (example below):
 
-The integration should now be showing on your list, along with a number of new entities for all the sensors it has created.
+```bash
+git tag -a v1.1.0 -m "Eon Next 1.1.0"
+git push origin v1.1.0
+```

--- a/custom_components/eon_next/__init__.py
+++ b/custom_components/eon_next/__init__.py
@@ -1,31 +1,49 @@
 #!/usr/bin/env python3
+"""The Eon Next integration."""
 
 import logging
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN, CONF_EMAIL, CONF_PASSWORD, PLATFORMS, DEFAULT_UPDATE_INTERVAL_MINUTES
 from .eonnext import EonNext
+from .coordinator import EonNextCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
-DOMAIN = "eon_next"
-CONF_EMAIL = "email"
-CONF_PASSWORD = "password"
 
-
-async def async_setup_entry(hass, entry):
-    """Set up platform from a ConfigEntry."""
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up Eon Next from a config entry."""
     hass.data.setdefault(DOMAIN, {})
 
     api = EonNext()
-    success = await api.login_with_username_and_password(entry.data[CONF_EMAIL], entry.data[CONF_PASSWORD])
+    success = await api.login_with_username_and_password(
+        entry.data[CONF_EMAIL], entry.data[CONF_PASSWORD]
+    )
 
-    if success == True:
-
-        hass.data[DOMAIN][entry.entry_id] = api
-
-        hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(entry, "sensor")
-        )
-
-        return True
-    
-    else:
+    if not success:
+        _LOGGER.error("Failed to authenticate with Eon Next")
         return False
+
+    coordinator = EonNextCoordinator(
+        hass, api, DEFAULT_UPDATE_INTERVAL_MINUTES
+    )
+    await coordinator.async_config_entry_first_refresh()
+
+    hass.data[DOMAIN][entry.entry_id] = {
+        "api": api,
+        "coordinator": coordinator,
+    }
+
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload an Eon Next config entry."""
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok:
+        entry_data = hass.data[DOMAIN].pop(entry.entry_id)
+        await entry_data["api"].async_close()
+    return unload_ok

--- a/custom_components/eon_next/__init__.py
+++ b/custom_components/eon_next/__init__.py
@@ -3,9 +3,6 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 
@@ -17,17 +14,7 @@ from .const import (
 )
 from .coordinator import EonNextCoordinator
 from .eonnext import EonNext
-
-
-@dataclass(slots=True)
-class EonNextRuntimeData:
-    """Runtime integration data stored on the config entry."""
-
-    api: EonNext
-    coordinator: EonNextCoordinator
-
-
-EonNextConfigEntry = ConfigEntry[EonNextRuntimeData]
+from .models import EonNextConfigEntry, EonNextRuntimeData
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: EonNextConfigEntry) -> bool:

--- a/custom_components/eon_next/config_flow.py
+++ b/custom_components/eon_next/config_flow.py
@@ -1,16 +1,19 @@
 """Config flow to configure Eon Next."""
+
 from __future__ import annotations
 
+from collections.abc import Mapping
 import logging
 from typing import Any
 
 import voluptuous as vol
 
 from homeassistant import config_entries
+from homeassistant.config_entries import ConfigEntry
 import homeassistant.helpers.config_validation as cv
 
+from .const import CONF_EMAIL, CONF_PASSWORD, DOMAIN
 from .eonnext import EonNext
-from .const import DOMAIN, CONF_EMAIL, CONF_PASSWORD
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -20,33 +23,104 @@ class EonNextConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    def __init__(self) -> None:
+        self._reauth_entry: ConfigEntry | None = None
+
+    async def _validate_credentials(self, email: str, password: str) -> bool:
+        """Validate credentials against E.ON Next."""
+        api = EonNext()
+        try:
+            return await api.login_with_username_and_password(
+                email,
+                password,
+                initialise=False,
+            )
+        except Exception:  # pylint: disable=broad-except
+            _LOGGER.exception("Unexpected error during authentication")
+            raise
+        finally:
+            await api.async_close()
+
     async def async_step_user(self, user_input: dict[str, Any] | None = None):
         """Invoked when a user initiates a flow via the user interface."""
-        errors = {}
+        errors: dict[str, str] = {}
+
         if user_input is not None:
-            en = EonNext()
+            email = user_input[CONF_EMAIL].strip().lower()
+            password = user_input[CONF_PASSWORD]
+
+            await self.async_set_unique_id(email)
+            self._abort_if_unique_id_configured()
+
             try:
-                success = await en.login_with_username_and_password(
-                    user_input[CONF_EMAIL],
-                    user_input[CONF_PASSWORD],
-                    False
-                )
-            except Exception:
-                _LOGGER.exception("Unexpected error during authentication")
+                success = await self._validate_credentials(email, password)
+            except Exception:  # pylint: disable=broad-except
                 errors["base"] = "unknown"
             else:
                 if success:
-                    await en.async_close()
-                    return self.async_create_entry(title="Eon Next", data={
-                        CONF_EMAIL: user_input[CONF_EMAIL],
-                        CONF_PASSWORD: user_input[CONF_PASSWORD]
-                    })
-                else:
-                    errors["base"] = "invalid_auth"
-            finally:
-                await en.async_close()
+                    return self.async_create_entry(
+                        title="Eon Next",
+                        data={CONF_EMAIL: email, CONF_PASSWORD: password},
+                    )
+                errors["base"] = "invalid_auth"
 
-        return self.async_show_form(step_id="user", data_schema=vol.Schema({
-            vol.Required(CONF_EMAIL): cv.string,
-            vol.Required(CONF_PASSWORD): cv.string
-        }), errors=errors)
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_EMAIL): cv.string,
+                    vol.Required(CONF_PASSWORD): cv.string,
+                }
+            ),
+            errors=errors,
+        )
+
+    async def async_step_reauth(self, entry_data: Mapping[str, Any]):
+        """Handle initiation of re-auth flow."""
+        del entry_data
+        self._reauth_entry = self.hass.config_entries.async_get_entry(
+            self.context["entry_id"]
+        )
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ):
+        """Handle confirmation of re-auth flow."""
+        errors: dict[str, str] = {}
+
+        if self._reauth_entry is None:
+            return self.async_abort(reason="unknown")
+
+        existing_email = self._reauth_entry.data[CONF_EMAIL]
+
+        if user_input is not None:
+            email = user_input[CONF_EMAIL].strip().lower()
+            password = user_input[CONF_PASSWORD]
+
+            try:
+                success = await self._validate_credentials(email, password)
+            except Exception:  # pylint: disable=broad-except
+                errors["base"] = "unknown"
+            else:
+                if success:
+                    return self.async_update_reload_and_abort(
+                        self._reauth_entry,
+                        data_updates={
+                            CONF_EMAIL: email,
+                            CONF_PASSWORD: password,
+                        },
+                        reason="reauth_successful",
+                    )
+                errors["base"] = "invalid_auth"
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_EMAIL, default=existing_email): cv.string,
+                    vol.Required(CONF_PASSWORD): cv.string,
+                }
+            ),
+            errors=errors,
+        )

--- a/custom_components/eon_next/const.py
+++ b/custom_components/eon_next/const.py
@@ -1,0 +1,10 @@
+"""Constants for the Eon Next integration."""
+
+DOMAIN = "eon_next"
+CONF_EMAIL = "email"
+CONF_PASSWORD = "password"
+PLATFORMS = ["sensor"]
+DEFAULT_UPDATE_INTERVAL_MINUTES = 30
+API_BASE_URL = "https://api.eonnext-kraken.energy/v1"
+GAS_CALORIC_VALUE = 38
+GAS_VOLUME_CORRECTION = 1.02264

--- a/custom_components/eon_next/coordinator.py
+++ b/custom_components/eon_next/coordinator.py
@@ -1,13 +1,22 @@
 """DataUpdateCoordinator for the Eon Next integration."""
 
+from __future__ import annotations
+
 import logging
 from datetime import timedelta
+from typing import Any
 
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .eonnext import EonNext, EonNextAuthError, EonNextApiError, METER_TYPE_GAS
+from .eonnext import EonNext, EonNextApiError, EonNextAuthError, METER_TYPE_GAS
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def ev_data_key(device_id: str) -> str:
+    """Create a stable coordinator key for EV devices."""
+    return f"ev::{device_id}"
 
 
 class EonNextCoordinator(DataUpdateCoordinator):
@@ -21,19 +30,19 @@ class EonNextCoordinator(DataUpdateCoordinator):
             update_interval=timedelta(minutes=update_interval_minutes),
         )
         self.api = api
-        self._consumption_available = None  # None = untested
 
-    async def _async_update_data(self) -> dict:
+    async def _async_update_data(self) -> dict[str, dict[str, Any]]:
         """Fetch data from the Eon Next API."""
-        data = {}
-        errors = []
+        data: dict[str, dict[str, Any]] = {}
+        errors: list[str] = []
 
         for account in self.api.accounts:
             for meter in account.meters:
+                meter_key = meter.serial
                 try:
                     await meter._update()
 
-                    meter_data = {
+                    meter_data: dict[str, Any] = {
                         "type": meter.type,
                         "serial": meter.serial,
                         "meter_id": meter.meter_id,
@@ -42,45 +51,78 @@ class EonNextCoordinator(DataUpdateCoordinator):
                         "latest_reading_date": meter.latest_reading_date,
                     }
 
-                    # Compute gas kWh from m3 reading
                     if meter.type == METER_TYPE_GAS and meter.latest_reading is not None:
                         meter_data["latest_reading_kwh"] = meter.get_latest_reading_kwh(
                             meter.latest_reading
                         )
 
-                    # Try REST consumption endpoint (half-hourly/daily data)
                     consumption = await self._fetch_consumption(meter)
                     if consumption is not None:
                         meter_data["consumption"] = consumption
                         meter_data["daily_consumption"] = self._sum_consumption(consumption)
 
-                    data[meter.serial] = meter_data
+                    data[meter_key] = meter_data
 
                 except EonNextAuthError as err:
                     _LOGGER.error("Authentication failed during update: %s", err)
-                    raise UpdateFailed(f"Authentication failed: {err}") from err
+                    raise ConfigEntryAuthFailed(
+                        f"Authentication failed during update: {err}"
+                    ) from err
                 except EonNextApiError as err:
                     _LOGGER.warning("API error updating meter %s: %s", meter.serial, err)
                     errors.append(str(err))
-                    # Preserve previous data for this meter if available
-                    if self.data and meter.serial in self.data:
-                        data[meter.serial] = self.data[meter.serial]
-                except Exception as err:
+                    if self.data and meter_key in self.data:
+                        data[meter_key] = self.data[meter_key]
+                except Exception as err:  # pylint: disable=broad-except
                     _LOGGER.warning("Unexpected error updating meter %s: %s", meter.serial, err)
                     errors.append(str(err))
-                    if self.data and meter.serial in self.data:
-                        data[meter.serial] = self.data[meter.serial]
+                    if self.data and meter_key in self.data:
+                        data[meter_key] = self.data[meter_key]
+
+            for charger in account.ev_chargers:
+                charger_key = ev_data_key(charger.device_id)
+                try:
+                    schedule = await self.api.async_get_smart_charging_schedule(
+                        charger.device_id
+                    )
+                    schedule_slots = self._schedule_slots(schedule)
+
+                    charger_data: dict[str, Any] = {
+                        "type": "ev_charger",
+                        "device_id": charger.device_id,
+                        "serial": charger.serial,
+                        "schedule": schedule_slots,
+                    }
+                    if schedule_slots:
+                        charger_data["next_charge_start"] = schedule_slots[0]["start"]
+                        charger_data["next_charge_end"] = schedule_slots[0]["end"]
+                    if len(schedule_slots) > 1:
+                        charger_data["next_charge_start_2"] = schedule_slots[1]["start"]
+                        charger_data["next_charge_end_2"] = schedule_slots[1]["end"]
+
+                    data[charger_key] = charger_data
+
+                except EonNextAuthError as err:
+                    _LOGGER.error("Authentication failed while updating EV data: %s", err)
+                    raise ConfigEntryAuthFailed(
+                        f"Authentication failed during EV update: {err}"
+                    ) from err
+                except EonNextApiError as err:
+                    _LOGGER.debug("EV API data unavailable for %s: %s", charger.serial, err)
+                    if self.data and charger_key in self.data:
+                        data[charger_key] = self.data[charger_key]
+                except Exception as err:  # pylint: disable=broad-except
+                    _LOGGER.debug("Unexpected EV update error for %s: %s", charger.serial, err)
+                    if self.data and charger_key in self.data:
+                        data[charger_key] = self.data[charger_key]
 
         if not data and errors:
-            raise UpdateFailed(f"Failed to fetch any meter data: {'; '.join(errors)}")
+            raise UpdateFailed(f"Failed to fetch any data: {'; '.join(errors)}")
 
         return data
 
-    async def _fetch_consumption(self, meter) -> list | None:
-        """Try to fetch consumption data from the REST API."""
-        if self._consumption_available is False:
-            return None
-
+    async def _fetch_consumption(self, meter) -> list[dict[str, Any]] | None:
+        """Try to fetch daily consumption from REST, then GraphQL fallback."""
         try:
             result = await self.api.async_get_consumption(
                 meter.type,
@@ -90,33 +132,78 @@ class EonNextCoordinator(DataUpdateCoordinator):
                 page_size=7,
             )
             if result and "results" in result and len(result["results"]) > 0:
-                self._consumption_available = True
                 return result["results"]
-            else:
-                if self._consumption_available is None:
-                    _LOGGER.debug(
-                        "REST consumption endpoint not available, "
-                        "falling back to meter readings only"
-                    )
-                self._consumption_available = False
-                return None
-        except Exception:
-            if self._consumption_available is None:
-                _LOGGER.debug(
-                    "REST consumption endpoint not available, "
-                    "falling back to meter readings only"
-                )
-            self._consumption_available = False
-            return None
+        except EonNextAuthError:
+            raise
+        except Exception as err:  # pylint: disable=broad-except
+            _LOGGER.debug(
+                "REST consumption unavailable for meter %s: %s",
+                meter.serial,
+                err,
+            )
+
+        try:
+            fallback = await self.api.async_get_consumption_data_by_mpxn(
+                meter.supply_point_id,
+                days=7,
+            )
+            if fallback:
+                return fallback
+        except EonNextAuthError:
+            raise
+        except Exception as err:  # pylint: disable=broad-except
+            _LOGGER.debug(
+                "GraphQL consumptionDataByMpxn fallback unavailable for meter %s: %s",
+                meter.serial,
+                err,
+            )
+
+        return None
 
     @staticmethod
-    def _sum_consumption(consumption_results: list) -> float | None:
-        """Sum consumption values from the REST API results."""
+    def _sum_consumption(consumption_results: list[dict[str, Any]]) -> float | None:
+        """Sum consumption values from consumption results."""
         if not consumption_results:
             return None
-        total = sum(
-            float(entry.get("consumption", 0))
-            for entry in consumption_results
-            if entry.get("consumption") is not None
-        )
+
+        total = 0.0
+        has_value = False
+        for entry in consumption_results:
+            consumption = entry.get("consumption")
+            if consumption is None:
+                continue
+            try:
+                total += float(consumption)
+                has_value = True
+            except (TypeError, ValueError):
+                continue
+
+        if not has_value:
+            return None
         return round(total, 3)
+
+    @staticmethod
+    def _schedule_slots(schedule: list[dict[str, Any]] | None) -> list[dict[str, Any]]:
+        """Normalize and sort EV schedule slots."""
+        if not schedule:
+            return []
+
+        slots = []
+        for item in schedule:
+            if not isinstance(item, dict):
+                continue
+            start = item.get("start")
+            end = item.get("end")
+            if not start or not end:
+                continue
+            slots.append(
+                {
+                    "start": start,
+                    "end": end,
+                    "type": item.get("type"),
+                    "energy_added_kwh": item.get("energyAddedKwh"),
+                }
+            )
+
+        slots.sort(key=lambda item: item["start"])
+        return slots

--- a/custom_components/eon_next/coordinator.py
+++ b/custom_components/eon_next/coordinator.py
@@ -1,0 +1,122 @@
+"""DataUpdateCoordinator for the Eon Next integration."""
+
+import logging
+from datetime import timedelta
+
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .eonnext import EonNext, EonNextAuthError, EonNextApiError, METER_TYPE_GAS
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class EonNextCoordinator(DataUpdateCoordinator):
+    """Coordinator to manage fetching Eon Next data."""
+
+    def __init__(self, hass, api: EonNext, update_interval_minutes: int = 30):
+        super().__init__(
+            hass,
+            _LOGGER,
+            name="Eon Next",
+            update_interval=timedelta(minutes=update_interval_minutes),
+        )
+        self.api = api
+        self._consumption_available = None  # None = untested
+
+    async def _async_update_data(self) -> dict:
+        """Fetch data from the Eon Next API."""
+        data = {}
+        errors = []
+
+        for account in self.api.accounts:
+            for meter in account.meters:
+                try:
+                    await meter._update()
+
+                    meter_data = {
+                        "type": meter.type,
+                        "serial": meter.serial,
+                        "meter_id": meter.meter_id,
+                        "supply_point_id": meter.supply_point_id,
+                        "latest_reading": meter.latest_reading,
+                        "latest_reading_date": meter.latest_reading_date,
+                    }
+
+                    # Compute gas kWh from m3 reading
+                    if meter.type == METER_TYPE_GAS and meter.latest_reading is not None:
+                        meter_data["latest_reading_kwh"] = meter.get_latest_reading_kwh(
+                            meter.latest_reading
+                        )
+
+                    # Try REST consumption endpoint (half-hourly/daily data)
+                    consumption = await self._fetch_consumption(meter)
+                    if consumption is not None:
+                        meter_data["consumption"] = consumption
+                        meter_data["daily_consumption"] = self._sum_consumption(consumption)
+
+                    data[meter.serial] = meter_data
+
+                except EonNextAuthError as err:
+                    _LOGGER.error("Authentication failed during update: %s", err)
+                    raise UpdateFailed(f"Authentication failed: {err}") from err
+                except EonNextApiError as err:
+                    _LOGGER.warning("API error updating meter %s: %s", meter.serial, err)
+                    errors.append(str(err))
+                    # Preserve previous data for this meter if available
+                    if self.data and meter.serial in self.data:
+                        data[meter.serial] = self.data[meter.serial]
+                except Exception as err:
+                    _LOGGER.warning("Unexpected error updating meter %s: %s", meter.serial, err)
+                    errors.append(str(err))
+                    if self.data and meter.serial in self.data:
+                        data[meter.serial] = self.data[meter.serial]
+
+        if not data and errors:
+            raise UpdateFailed(f"Failed to fetch any meter data: {'; '.join(errors)}")
+
+        return data
+
+    async def _fetch_consumption(self, meter) -> list | None:
+        """Try to fetch consumption data from the REST API."""
+        if self._consumption_available is False:
+            return None
+
+        try:
+            result = await self.api.async_get_consumption(
+                meter.type,
+                meter.supply_point_id,
+                meter.serial,
+                group_by="day",
+                page_size=7,
+            )
+            if result and "results" in result and len(result["results"]) > 0:
+                self._consumption_available = True
+                return result["results"]
+            else:
+                if self._consumption_available is None:
+                    _LOGGER.debug(
+                        "REST consumption endpoint not available, "
+                        "falling back to meter readings only"
+                    )
+                self._consumption_available = False
+                return None
+        except Exception:
+            if self._consumption_available is None:
+                _LOGGER.debug(
+                    "REST consumption endpoint not available, "
+                    "falling back to meter readings only"
+                )
+            self._consumption_available = False
+            return None
+
+    @staticmethod
+    def _sum_consumption(consumption_results: list) -> float | None:
+        """Sum consumption values from the REST API results."""
+        if not consumption_results:
+            return None
+        total = sum(
+            float(entry.get("consumption", 0))
+            for entry in consumption_results
+            if entry.get("consumption") is not None
+        )
+        return round(total, 3)

--- a/custom_components/eon_next/eonnext.py
+++ b/custom_components/eon_next/eonnext.py
@@ -1,8 +1,13 @@
 #!/usr/bin/env python3
 
-import aiohttp
+from __future__ import annotations
+
 import datetime
 import logging
+from dataclasses import dataclass
+from typing import Any
+
+import aiohttp
 
 from .const import API_BASE_URL
 
@@ -11,6 +16,73 @@ _LOGGER = logging.getLogger(__name__)
 METER_TYPE_GAS = "gas"
 METER_TYPE_ELECTRIC = "electricity"
 METER_TYPE_UNKNOWN = "unknown"
+
+CONSUMPTION_DATA_BY_MPXN_QUERY = """
+query consumptionDataByMpxn($startDate: String!, $endDate: String!, $limit: Int!, $mpxn: ID!) {
+  consumptionDataByMpxn(
+    startDate: $startDate
+    endDate: $endDate
+    limit: $limit
+    mpxn: $mpxn
+  ) {
+    __typename
+    items {
+      __typename
+      mpxn
+      period
+      fuel
+      data {
+        __typename
+        costs {
+          __typename
+          source
+          consumption
+          cost
+          costIncVat
+          consumptionOutsideTolerances
+        }
+        standingCharge
+        standingChargeIncVat
+        totalCharge
+        totalChargeIncVat
+      }
+    }
+  }
+}
+"""
+
+GET_ACCOUNT_DEVICES_QUERY = """
+query getAccountDevices($accountNumber: String!) {
+  devices(accountNumber: $accountNumber) {
+    id
+    provider
+    deviceType
+    status {
+      current
+    }
+    __typename
+    ... on SmartFlexVehicle {
+      make
+      model
+    }
+    ... on SmartFlexChargePoint {
+      make
+      model
+    }
+  }
+}
+"""
+
+GET_SMART_CHARGING_SCHEDULE_QUERY = """
+query getSmartChargingSchedule($deviceId: String!) {
+  flexPlannedDispatches(deviceId: $deviceId) {
+    start
+    end
+    type
+    energyAddedKwh
+  }
+}
+"""
 
 
 class EonNextAuthError(Exception):
@@ -21,64 +93,88 @@ class EonNextApiError(Exception):
     """Raised when an API call fails."""
 
 
+@dataclass(slots=True)
+class SmartChargingDevice:
+    """Smart charging device metadata."""
+
+    device_id: str
+    serial: str
+
+
 class EonNext:
+    """API client for E.ON Next."""
 
     def __init__(self):
         self.username = ""
         self.password = ""
-        self._session = None
+        self._session: aiohttp.ClientSession | None = None
         self.__reset_authentication()
         self.__reset_accounts()
 
-    def _json_contains_key_chain(self, data: dict, key_chain: list) -> bool:
+    def _json_contains_key_chain(self, data: Any, key_chain: list[str]) -> bool:
         for key in key_chain:
-            if key in data:
-                data = data[key]
-            else:
+            if not isinstance(data, dict) or key not in data:
                 return False
+            data = data[key]
         return True
 
+    @staticmethod
+    def _has_auth_error(errors: Any) -> bool:
+        if not isinstance(errors, list):
+            return False
+
+        for error in errors:
+            if not isinstance(error, dict):
+                continue
+
+            message = str(error.get("message", "")).lower()
+            code = str(error.get("extensions", {}).get("code", "")).lower()
+            if (
+                "authentication" in message
+                or "authenticated" in message
+                or "token" in message
+                or "unauthor" in message
+                or "jwt" in message
+                or "unauthenticated" in code
+                or "invalid_token" in code
+            ):
+                return True
+        return False
+
     def __current_timestamp(self) -> int:
-        now = datetime.datetime.now()
-        return int(datetime.datetime.timestamp(now))
+        return int(datetime.datetime.now().timestamp())
 
     def __reset_authentication(self):
         self.auth = {
             "issued": None,
-            "token": {
-                "token": None,
-                "expires": None
-            },
-            "refresh": {
-                "token": None,
-                "expires": None
-            }
+            "token": {"token": None, "expires": None},
+            "refresh": {"token": None, "expires": None},
         }
 
     def __store_authentication(self, kraken_token: dict):
         self.auth = {
-            "issued": kraken_token['payload']['iat'],
+            "issued": kraken_token["payload"]["iat"],
             "token": {
-                "token": kraken_token['token'],
-                "expires": kraken_token['payload']['exp']
+                "token": kraken_token["token"],
+                "expires": kraken_token["payload"]["exp"],
             },
             "refresh": {
-                "token": kraken_token['refreshToken'],
-                "expires": kraken_token['refreshExpiresIn']
-            }
+                "token": kraken_token["refreshToken"],
+                "expires": kraken_token["refreshExpiresIn"],
+            },
         }
 
     def __auth_token_is_valid(self) -> bool:
-        if self.auth['token']['token'] is None:
+        if self.auth["token"]["token"] is None:
             return False
-        if self.auth['token']['expires'] <= self.__current_timestamp():
+        if self.auth["token"]["expires"] <= self.__current_timestamp():
             return False
         return True
 
     def __refresh_token_is_valid(self) -> bool:
-        if self.auth['refresh']['token'] is None:
+        if self.auth["refresh"]["token"] is None:
             return False
-        if self.auth['refresh']['expires'] <= self.__current_timestamp():
+        if self.auth["refresh"]["expires"] <= self.__current_timestamp():
             return False
         return True
 
@@ -88,13 +184,14 @@ class EonNext:
                 await self.__login_with_refresh_token()
             else:
                 await self.login_with_username_and_password(
-                    self.username, self.password
+                    self.username,
+                    self.password,
                 )
 
         if not self.__auth_token_is_valid():
             raise EonNextAuthError("Unable to authenticate")
 
-        return self.auth['token']['token']
+        return self.auth["token"]["token"]
 
     async def _get_session(self) -> aiohttp.ClientSession:
         if self._session is None or self._session.closed:
@@ -106,27 +203,57 @@ class EonNext:
             await self._session.close()
             self._session = None
 
-    async def _graphql_post(self, operation: str, query: str, variables: dict = None, authenticated: bool = True) -> dict:
+    async def _graphql_post(
+        self,
+        operation: str,
+        query: str,
+        variables: dict | None = None,
+        authenticated: bool = True,
+    ) -> dict:
         if variables is None:
             variables = {}
 
-        use_headers = {}
+        headers: dict[str, str] = {}
         if authenticated:
-            use_headers['authorization'] = "JWT " + await self.__auth_token()
+            headers["authorization"] = f"JWT {await self.__auth_token()}"
 
         session = await self._get_session()
         try:
             async with session.post(
                 f"{API_BASE_URL}/graphql/",
                 json={"operationName": operation, "variables": variables, "query": query},
-                headers=use_headers
+                headers=headers,
             ) as response:
-                return await response.json()
+                if authenticated and response.status in (401, 403):
+                    raise EonNextAuthError("Authentication rejected by API")
+
+                try:
+                    result = await response.json(content_type=None)
+                except aiohttp.ContentTypeError as err:
+                    text = await response.text()
+                    _LOGGER.debug(
+                        "Non-JSON response for %s (status %s): %s",
+                        operation,
+                        response.status,
+                        text[:500],
+                    )
+                    raise EonNextApiError("Invalid API response") from err
+
+                if self._has_auth_error(result.get("errors")):
+                    raise EonNextAuthError("Authentication failed")
+
+                return result
+
         except aiohttp.ClientError as err:
             _LOGGER.error("GraphQL request failed for %s: %s", operation, err)
             raise EonNextApiError(f"API request failed: {err}") from err
 
-    async def login_with_username_and_password(self, username: str = None, password: str = None, initialise: bool = True) -> bool:
+    async def login_with_username_and_password(
+        self,
+        username: str | None = None,
+        password: str | None = None,
+        initialise: bool = True,
+    ) -> bool:
         if username is not None:
             self.username = username
         if password is not None:
@@ -139,27 +266,27 @@ class EonNext:
                 {
                     "input": {
                         "email": self.username,
-                        "password": self.password
+                        "password": self.password,
                     }
                 },
-                False
+                False,
             )
-        except EonNextApiError:
+        except (EonNextApiError, EonNextAuthError):
             self.__reset_authentication()
             return False
 
         if self._json_contains_key_chain(result, ["data", "obtainKrakenToken", "token"]):
-            self.__store_authentication(result['data']['obtainKrakenToken'])
+            self.__store_authentication(result["data"]["obtainKrakenToken"])
             if initialise:
                 await self.__init_accounts()
             return True
-        else:
-            _LOGGER.error("Authentication failed: %s", result.get("errors", "Unknown error"))
-            self.__reset_authentication()
-            return False
+
+        _LOGGER.error("Authentication failed: %s", result.get("errors", "Unknown error"))
+        self.__reset_authentication()
+        return False
 
     async def login_with_refresh_token(self, token: str) -> bool:
-        self.auth['refresh']['token'] = token
+        self.auth["refresh"]["token"] = token
         return await self.__login_with_refresh_token(True)
 
     async def __login_with_refresh_token(self, initialise: bool = False) -> bool:
@@ -167,52 +294,58 @@ class EonNext:
             result = await self._graphql_post(
                 "refreshToken",
                 "mutation refreshToken($input: ObtainJSONWebTokenInput!) {  obtainKrakenToken(input: $input) {    payload    refreshExpiresIn    refreshToken    token    __typename  }}",
-                {
-                    "input": {
-                        "refreshToken": self.auth['refresh']['token']
-                    }
-                },
-                False
+                {"input": {"refreshToken": self.auth["refresh"]["token"]}},
+                False,
             )
-        except EonNextApiError:
+        except (EonNextApiError, EonNextAuthError):
             self.__reset_authentication()
             return False
 
         if self._json_contains_key_chain(result, ["data", "obtainKrakenToken", "token"]):
-            self.__store_authentication(result['data']['obtainKrakenToken'])
+            self.__store_authentication(result["data"]["obtainKrakenToken"])
             if initialise:
                 await self.__init_accounts()
             return True
-        else:
-            self.__reset_authentication()
-            return False
+
+        self.__reset_authentication()
+        return False
 
     def __reset_accounts(self):
-        self.accounts = []
+        self.accounts: list[EnergyAccount] = []
 
-    async def __get_account_numbers(self) -> list:
+    async def __get_account_numbers(self) -> list[str]:
         result = await self._graphql_post(
             "headerGetLoggedInUser",
-            "query headerGetLoggedInUser {\n  viewer {\n    accounts {\n      ... on AccountType {\n        applications(first: 1) {\n          edges {\n            node {\n              isMigrated\n              migrationSource\n              __typename\n            }\n            __typename\n          }\n          __typename\n        }\n        balance\n        id\n        number\n        __typename\n      }\n      __typename\n    }\n    id\n    preferredName\n    __typename\n  }\n}\n"
+            "query headerGetLoggedInUser {\n  viewer {\n    accounts {\n      ... on AccountType {\n        applications(first: 1) {\n          edges {\n            node {\n              isMigrated\n              migrationSource\n              __typename\n            }\n            __typename\n          }\n          __typename\n        }\n        balance\n        id\n        number\n        __typename\n      }\n      __typename\n    }\n    id\n    preferredName\n    __typename\n  }\n}\n",
         )
 
         if not self._json_contains_key_chain(result, ["data", "viewer", "accounts"]):
             raise EonNextApiError("Unable to load energy accounts")
 
         found = []
-        for account_entry in result['data']['viewer']['accounts']:
-            found.append(account_entry['number'])
+        for account_entry in result["data"]["viewer"]["accounts"]:
+            found.append(account_entry["number"])
 
         return found
 
     async def __init_accounts(self):
-        if len(self.accounts) == 0:
-            for account_number in await self.__get_account_numbers():
-                account = EnergyAccount(self, account_number)
-                await account._load_meters()
-                self.accounts.append(account)
+        if len(self.accounts) != 0:
+            return
 
-    async def async_get_consumption(self, meter_type: str, supply_point_id: str, serial: str, group_by: str = "day", page_size: int = 10) -> dict | None:
+        for account_number in await self.__get_account_numbers():
+            account = EnergyAccount(self, account_number)
+            await account._load_meters()
+            await account._load_ev_chargers()
+            self.accounts.append(account)
+
+    async def async_get_consumption(
+        self,
+        meter_type: str,
+        supply_point_id: str,
+        serial: str,
+        group_by: str = "day",
+        page_size: int = 10,
+    ) -> dict | None:
         """Fetch consumption data from the REST API endpoint."""
         if not supply_point_id:
             return None
@@ -232,27 +365,117 @@ class EonNext:
         session = await self._get_session()
         try:
             async with session.get(url, params=params, headers=headers) as response:
+                if response.status in (401, 403):
+                    raise EonNextAuthError("Authentication rejected by API")
+
                 if response.status == 200:
                     data = await response.json()
                     if "results" in data:
                         return data
                     return None
+
                 _LOGGER.debug(
                     "REST consumption endpoint returned status %s for %s",
-                    response.status, serial
+                    response.status,
+                    serial,
                 )
                 return None
         except aiohttp.ClientError as err:
             _LOGGER.debug("REST consumption request failed for %s: %s", serial, err)
             return None
 
+    async def async_get_consumption_data_by_mpxn(
+        self,
+        mpxn: str,
+        days: int = 7,
+    ) -> list[dict[str, Any]] | None:
+        """Fetch daily consumption data via the GraphQL consumptionDataByMpxn query."""
+        if not mpxn:
+            return None
+
+        end_date = datetime.date.today()
+        start_date = end_date - datetime.timedelta(days=max(days - 1, 0))
+        variables = {
+            "startDate": start_date.isoformat(),
+            "endDate": end_date.isoformat(),
+            "limit": days,
+            "mpxn": mpxn,
+        }
+
+        result = await self._graphql_post(
+            "consumptionDataByMpxn",
+            CONSUMPTION_DATA_BY_MPXN_QUERY,
+            variables,
+        )
+        if not self._json_contains_key_chain(result, ["data", "consumptionDataByMpxn", "items"]):
+            return None
+
+        items = result["data"]["consumptionDataByMpxn"].get("items", [])
+        normalized: list[dict[str, Any]] = []
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+
+            costs = item.get("data", {}).get("costs", [])
+            if not isinstance(costs, list):
+                continue
+
+            total = 0.0
+            has_value = False
+            for cost_entry in costs:
+                if not isinstance(cost_entry, dict):
+                    continue
+                consumption = cost_entry.get("consumption")
+                if consumption is None:
+                    continue
+                try:
+                    total += float(consumption)
+                    has_value = True
+                except (TypeError, ValueError):
+                    continue
+
+            if not has_value:
+                continue
+
+            normalized.append(
+                {
+                    "interval_start": item.get("period"),
+                    "consumption": round(total, 3),
+                }
+            )
+
+        return normalized or None
+
+    async def async_get_smart_charging_schedule(
+        self,
+        device_id: str,
+    ) -> list[dict[str, Any]] | None:
+        """Fetch smart charging schedule for a specific EV device."""
+        if not device_id:
+            return None
+
+        result = await self._graphql_post(
+            "getSmartChargingSchedule",
+            GET_SMART_CHARGING_SCHEDULE_QUERY,
+            {"deviceId": device_id},
+        )
+        if not self._json_contains_key_chain(result, ["data", "flexPlannedDispatches"]):
+            return None
+
+        schedule = result["data"]["flexPlannedDispatches"]
+        if isinstance(schedule, list):
+            return schedule
+        return None
+
 
 class EnergyAccount:
+    """Represents an energy account."""
 
     def __init__(self, api: EonNext, account_number: str):
         self.api = api
         self.account_number = account_number
-        self.meters = []
+        self.meters: list[EnergyMeter] = []
+        self.ev_chargers: list[SmartChargingDevice] = []
 
     async def _load_meters(self):
         result = await self.api._graphql_post(
@@ -260,8 +483,8 @@ class EnergyAccount:
             "query getAccountMeterSelector($accountNumber: String!, $showInactive: Boolean!) {\n  properties(accountNumber: $accountNumber) {\n    ...MeterSelectorPropertyFields\n    __typename\n  }\n}\n\nfragment MeterSelectorPropertyFields on PropertyType {\n  __typename\n  electricityMeterPoints {\n    ...MeterSelectorElectricityMeterPointFields\n    __typename\n  }\n  gasMeterPoints {\n    ...MeterSelectorGasMeterPointFields\n    __typename\n  }\n  id\n  postcode\n}\n\nfragment MeterSelectorElectricityMeterPointFields on ElectricityMeterPointType {\n  __typename\n  id\n  mpan\n  meters(includeInactive: $showInactive) {\n    ...MeterSelectorElectricityMeterFields\n    __typename\n  }\n}\n\nfragment MeterSelectorElectricityMeterFields on ElectricityMeterType {\n  __typename\n  activeTo\n  id\n  registers {\n    id\n    name\n    __typename\n  }\n  serialNumber\n}\n\nfragment MeterSelectorGasMeterPointFields on GasMeterPointType {\n  __typename\n  id\n  mprn\n  meters(includeInactive: $showInactive) {\n    ...MeterSelectorGasMeterFields\n    __typename\n  }\n}\n\nfragment MeterSelectorGasMeterFields on GasMeterType {\n  __typename\n  activeTo\n  id\n  registers {\n    id\n    name\n    __typename\n  }\n  serialNumber\n}\n",
             {
                 "accountNumber": self.account_number,
-                "showInactive": False
-            }
+                "showInactive": False,
+            },
         )
 
         if not self.api._json_contains_key_chain(result, ["data", "properties"]):
@@ -270,33 +493,94 @@ class EnergyAccount:
             )
 
         self.meters = []
-        for prop in result['data']['properties']:
-            for electricity_point in prop['electricityMeterPoints']:
-                supply_point_id = electricity_point.get('mpan') or electricity_point.get('id', '')
-                for meter_config in electricity_point['meters']:
+        for prop in result["data"]["properties"]:
+            for electricity_point in prop["electricityMeterPoints"]:
+                supply_point_id = electricity_point.get("mpan") or electricity_point.get(
+                    "id",
+                    "",
+                )
+                for meter_config in electricity_point["meters"]:
                     meter = ElectricityMeter(
                         self,
-                        meter_config['id'],
-                        meter_config['serialNumber'],
+                        meter_config["id"],
+                        meter_config["serialNumber"],
                         supply_point_id,
                     )
                     self.meters.append(meter)
 
-            for gas_point in prop['gasMeterPoints']:
-                supply_point_id = gas_point.get('mprn') or gas_point.get('id', '')
-                for meter_config in gas_point['meters']:
+            for gas_point in prop["gasMeterPoints"]:
+                supply_point_id = gas_point.get("mprn") or gas_point.get("id", "")
+                for meter_config in gas_point["meters"]:
                     meter = GasMeter(
                         self,
-                        meter_config['id'],
-                        meter_config['serialNumber'],
+                        meter_config["id"],
+                        meter_config["serialNumber"],
                         supply_point_id,
                     )
                     self.meters.append(meter)
+
+    async def _load_ev_chargers(self):
+        """Load SmartFlex EV devices if available for the account."""
+        self.ev_chargers = []
+        try:
+            result = await self.api._graphql_post(
+                "getAccountDevices",
+                GET_ACCOUNT_DEVICES_QUERY,
+                {"accountNumber": self.account_number},
+            )
+        except (EonNextApiError, EonNextAuthError) as err:
+            _LOGGER.debug("Unable to load EV devices for %s: %s", self.account_number, err)
+            return
+
+        if not self.api._json_contains_key_chain(result, ["data", "devices"]):
+            return
+
+        seen: set[str] = set()
+        for device in result["data"]["devices"]:
+            if not isinstance(device, dict):
+                continue
+
+            device_id = device.get("id")
+            if not device_id or device_id in seen:
+                continue
+
+            status = device.get("status", {}).get("current")
+            if status and status != "LIVE":
+                continue
+
+            device_type = str(device.get("deviceType", "")).upper()
+            typename = str(device.get("__typename", ""))
+            is_ev_device = (
+                "SMARTFLEX" in typename.upper()
+                or "SMART_FLEX" in device_type
+                or "VEHICLE" in device_type
+                or "CHARGE_POINT" in device_type
+            )
+            if not is_ev_device:
+                continue
+
+            make = str(device.get("make") or "").strip()
+            model = str(device.get("model") or "").strip()
+            display_name = " ".join(part for part in [make, model] if part).strip()
+            if not display_name:
+                display_name = str(device.get("provider") or device_id)
+
+            self.ev_chargers.append(
+                SmartChargingDevice(device_id=device_id, serial=display_name)
+            )
+            seen.add(device_id)
 
 
 class EnergyMeter:
+    """Base class for meters."""
 
-    def __init__(self, account: EnergyAccount, meter_id: str, serial: str, supply_point_id: str = ""):
+    def __init__(
+        self,
+        account: EnergyAccount,
+        meter_id: str,
+        serial: str,
+        supply_point_id: str = "",
+    ):
         self.account = account
         self.api = account.api
 
@@ -316,15 +600,26 @@ class EnergyMeter:
 
     def _convert_datetime_str_to_date(self, datetime_str: str) -> datetime.date:
         date_chunks = str(datetime_str.split("T")[0]).split("-")
-        return datetime.date(int(date_chunks[0]), int(date_chunks[1]), int(date_chunks[2]))
+        return datetime.date(
+            int(date_chunks[0]),
+            int(date_chunks[1]),
+            int(date_chunks[2]),
+        )
 
     async def _update(self):
         pass
 
 
 class ElectricityMeter(EnergyMeter):
+    """Electricity meter."""
 
-    def __init__(self, account: EnergyAccount, meter_id: str, serial: str, supply_point_id: str = ""):
+    def __init__(
+        self,
+        account: EnergyAccount,
+        meter_id: str,
+        serial: str,
+        supply_point_id: str = "",
+    ):
         super().__init__(account, meter_id, serial, supply_point_id)
         self.type = METER_TYPE_ELECTRIC
 
@@ -335,23 +630,32 @@ class ElectricityMeter(EnergyMeter):
             {
                 "accountNumber": self.account.account_number,
                 "cursor": "",
-                "meterId": self.meter_id
-            }
+                "meterId": self.meter_id,
+            },
         )
 
         if not self.api._json_contains_key_chain(result, ["data", "readings"]):
             _LOGGER.warning("Unable to load readings for meter %s", self.serial)
             return
 
-        readings = result['data']['readings']['edges']
+        readings = result["data"]["readings"]["edges"]
         if len(readings) > 0:
-            self.latest_reading = round(float(readings[0]['node']['registers'][0]['value']))
-            self.latest_reading_date = self._convert_datetime_str_to_date(readings[0]['node']['readAt'])
+            self.latest_reading = round(float(readings[0]["node"]["registers"][0]["value"]))
+            self.latest_reading_date = self._convert_datetime_str_to_date(
+                readings[0]["node"]["readAt"]
+            )
 
 
 class GasMeter(EnergyMeter):
+    """Gas meter."""
 
-    def __init__(self, account: EnergyAccount, meter_id: str, serial: str, supply_point_id: str = ""):
+    def __init__(
+        self,
+        account: EnergyAccount,
+        meter_id: str,
+        serial: str,
+        supply_point_id: str = "",
+    ):
         super().__init__(account, meter_id, serial, supply_point_id)
         self.type = METER_TYPE_GAS
 
@@ -362,22 +666,25 @@ class GasMeter(EnergyMeter):
             {
                 "accountNumber": self.account.account_number,
                 "cursor": "",
-                "meterId": self.meter_id
-            }
+                "meterId": self.meter_id,
+            },
         )
 
         if not self.api._json_contains_key_chain(result, ["data", "readings"]):
             _LOGGER.warning("Unable to load readings for meter %s", self.serial)
             return
 
-        readings = result['data']['readings']['edges']
+        readings = result["data"]["readings"]["edges"]
         if len(readings) > 0:
-            self.latest_reading = round(float(readings[0]['node']['registers'][0]['value']))
-            self.latest_reading_date = self._convert_datetime_str_to_date(readings[0]['node']['readAt'])
+            self.latest_reading = round(float(readings[0]["node"]["registers"][0]["value"]))
+            self.latest_reading_date = self._convert_datetime_str_to_date(
+                readings[0]["node"]["readAt"]
+            )
 
     def get_latest_reading_kwh(self, m3_value: float) -> float:
         """Convert gas m3 reading to kWh."""
         from .const import GAS_CALORIC_VALUE, GAS_VOLUME_CORRECTION
+
         kwh = m3_value * GAS_VOLUME_CORRECTION
         kwh = kwh * GAS_CALORIC_VALUE
         kwh = kwh / 3.6

--- a/custom_components/eon_next/eonnext.py
+++ b/custom_components/eon_next/eonnext.py
@@ -2,10 +2,23 @@
 
 import aiohttp
 import datetime
+import logging
+
+from .const import API_BASE_URL
+
+_LOGGER = logging.getLogger(__name__)
 
 METER_TYPE_GAS = "gas"
 METER_TYPE_ELECTRIC = "electricity"
 METER_TYPE_UNKNOWN = "unknown"
+
+
+class EonNextAuthError(Exception):
+    """Raised when authentication fails."""
+
+
+class EonNextApiError(Exception):
+    """Raised when an API call fails."""
 
 
 class EonNext:
@@ -13,9 +26,9 @@ class EonNext:
     def __init__(self):
         self.username = ""
         self.password = ""
-        self.__reset_authentation()
+        self._session = None
+        self.__reset_authentication()
         self.__reset_accounts()
-    
 
     def _json_contains_key_chain(self, data: dict, key_chain: list) -> bool:
         for key in key_chain:
@@ -24,14 +37,12 @@ class EonNext:
             else:
                 return False
         return True
-    
 
     def __current_timestamp(self) -> int:
         now = datetime.datetime.now()
         return int(datetime.datetime.timestamp(now))
 
-
-    def __reset_authentation(self):
+    def __reset_authentication(self):
         self.auth = {
             "issued": None,
             "token": {
@@ -43,7 +54,7 @@ class EonNext:
                 "expires": None
             }
         }
-    
+
     def __store_authentication(self, kraken_token: dict):
         self.auth = {
             "issued": kraken_token['payload']['iat'],
@@ -56,139 +67,184 @@ class EonNext:
                 "expires": kraken_token['refreshExpiresIn']
             }
         }
-    
 
     def __auth_token_is_valid(self) -> bool:
-        if self.auth['token']['token'] == None:
+        if self.auth['token']['token'] is None:
             return False
-        
         if self.auth['token']['expires'] <= self.__current_timestamp():
             return False
-        
         return True
-    
 
     def __refresh_token_is_valid(self) -> bool:
-        if self.auth['refresh']['token'] == None:
+        if self.auth['refresh']['token'] is None:
             return False
-        
         if self.auth['refresh']['expires'] <= self.__current_timestamp():
             return False
-        
         return True
-    
 
     async def __auth_token(self) -> str:
-        if self.__auth_token_is_valid() == False:
-            if self.__refresh_token_is_valid() == True:
+        if not self.__auth_token_is_valid():
+            if self.__refresh_token_is_valid():
                 await self.__login_with_refresh_token()
             else:
-                await self.login_with_username_and_password()
-        
-        if self.__auth_token_is_valid() == False:
-            raise Exception("Unable to authenticate")
+                await self.login_with_username_and_password(
+                    self.username, self.password
+                )
+
+        if not self.__auth_token_is_valid():
+            raise EonNextAuthError("Unable to authenticate")
 
         return self.auth['token']['token']
-    
 
-    async def _graphql_post(self, operation: str, query: str, variables: dict={}, authenticated: bool = True) -> dict:
+    async def _get_session(self) -> aiohttp.ClientSession:
+        if self._session is None or self._session.closed:
+            self._session = aiohttp.ClientSession()
+        return self._session
+
+    async def async_close(self):
+        if self._session and not self._session.closed:
+            await self._session.close()
+            self._session = None
+
+    async def _graphql_post(self, operation: str, query: str, variables: dict = None, authenticated: bool = True) -> dict:
+        if variables is None:
+            variables = {}
+
         use_headers = {}
-
-        if authenticated == True:
+        if authenticated:
             use_headers['authorization'] = "JWT " + await self.__auth_token()
 
-        async with aiohttp.ClientSession() as session:
+        session = await self._get_session()
+        try:
             async with session.post(
-                "https://api.eonnext-kraken.energy/v1/graphql/",
+                f"{API_BASE_URL}/graphql/",
                 json={"operationName": operation, "variables": variables, "query": query},
                 headers=use_headers
             ) as response:
                 return await response.json()
-    
+        except aiohttp.ClientError as err:
+            _LOGGER.error("GraphQL request failed for %s: %s", operation, err)
+            raise EonNextApiError(f"API request failed: {err}") from err
 
-    async def login_with_username_and_password(self, username: str, password: str, initialise: bool = True) -> bool:
-        self.username = username
-        self.password = password
-        
-        result = await self._graphql_post(
-            "loginEmailAuthentication",
-            "mutation loginEmailAuthentication($input: ObtainJSONWebTokenInput!) {obtainKrakenToken(input: $input) {    payload    refreshExpiresIn    refreshToken    token    __typename}}",
-            {
-                "input": {
-                    "email": self.username,
-                    "password": self.password
-                }
-            },
-            False
-        )
+    async def login_with_username_and_password(self, username: str = None, password: str = None, initialise: bool = True) -> bool:
+        if username is not None:
+            self.username = username
+        if password is not None:
+            self.password = password
 
-        if self._json_contains_key_chain(result, ["data", "obtainKrakenToken", "token"]) == True:
+        try:
+            result = await self._graphql_post(
+                "loginEmailAuthentication",
+                "mutation loginEmailAuthentication($input: ObtainJSONWebTokenInput!) {obtainKrakenToken(input: $input) {    payload    refreshExpiresIn    refreshToken    token    __typename}}",
+                {
+                    "input": {
+                        "email": self.username,
+                        "password": self.password
+                    }
+                },
+                False
+            )
+        except EonNextApiError:
+            self.__reset_authentication()
+            return False
+
+        if self._json_contains_key_chain(result, ["data", "obtainKrakenToken", "token"]):
             self.__store_authentication(result['data']['obtainKrakenToken'])
-            if initialise == True:
+            if initialise:
                 await self.__init_accounts()
             return True
         else:
-            self.__reset_authentation()
+            _LOGGER.error("Authentication failed: %s", result.get("errors", "Unknown error"))
+            self.__reset_authentication()
             return False
-    
 
     async def login_with_refresh_token(self, token: str) -> bool:
         self.auth['refresh']['token'] = token
         return await self.__login_with_refresh_token(True)
-    
 
     async def __login_with_refresh_token(self, initialise: bool = False) -> bool:
-        result = await self._graphql_post(
-            "refreshToken",
-            "mutation refreshToken($input: ObtainJSONWebTokenInput!) {  obtainKrakenToken(input: $input) {    payload    refreshExpiresIn    refreshToken    token    __typename  }}",
-            {
-                "input": {
-                    "refreshToken": self.auth['refresh']['token']
-                }
-            },
-            False
-        )
+        try:
+            result = await self._graphql_post(
+                "refreshToken",
+                "mutation refreshToken($input: ObtainJSONWebTokenInput!) {  obtainKrakenToken(input: $input) {    payload    refreshExpiresIn    refreshToken    token    __typename  }}",
+                {
+                    "input": {
+                        "refreshToken": self.auth['refresh']['token']
+                    }
+                },
+                False
+            )
+        except EonNextApiError:
+            self.__reset_authentication()
+            return False
 
-        if self._json_contains_key_chain(result, ["data", "obtainKrakenToken", "token"]) == True:
+        if self._json_contains_key_chain(result, ["data", "obtainKrakenToken", "token"]):
             self.__store_authentication(result['data']['obtainKrakenToken'])
-            if initialise == True:
+            if initialise:
                 await self.__init_accounts()
             return True
         else:
-            self.__reset_authentation()
+            self.__reset_authentication()
             return False
-    
 
     def __reset_accounts(self):
         self.accounts = []
-    
 
     async def __get_account_numbers(self) -> list:
         result = await self._graphql_post(
             "headerGetLoggedInUser",
             "query headerGetLoggedInUser {\n  viewer {\n    accounts {\n      ... on AccountType {\n        applications(first: 1) {\n          edges {\n            node {\n              isMigrated\n              migrationSource\n              __typename\n            }\n            __typename\n          }\n          __typename\n        }\n        balance\n        id\n        number\n        __typename\n      }\n      __typename\n    }\n    id\n    preferredName\n    __typename\n  }\n}\n"
         )
-        
-        if self._json_contains_key_chain(result, ["data", "viewer", "accounts"]) == False:
-            raise Exception("Unable to load energy accounts")
+
+        if not self._json_contains_key_chain(result, ["data", "viewer", "accounts"]):
+            raise EonNextApiError("Unable to load energy accounts")
 
         found = []
         for account_entry in result['data']['viewer']['accounts']:
             found.append(account_entry['number'])
 
         return found
-    
 
     async def __init_accounts(self):
         if len(self.accounts) == 0:
             for account_number in await self.__get_account_numbers():
-
                 account = EnergyAccount(self, account_number)
                 await account._load_meters()
-
                 self.accounts.append(account)
 
+    async def async_get_consumption(self, meter_type: str, supply_point_id: str, serial: str, group_by: str = "day", page_size: int = 10) -> dict | None:
+        """Fetch consumption data from the REST API endpoint."""
+        if not supply_point_id:
+            return None
 
+        token = await self.__auth_token()
+
+        if meter_type == METER_TYPE_ELECTRIC:
+            url = f"{API_BASE_URL}/electricity-meter-points/{supply_point_id}/meters/{serial}/consumption/"
+        elif meter_type == METER_TYPE_GAS:
+            url = f"{API_BASE_URL}/gas-meter-points/{supply_point_id}/meters/{serial}/consumption/"
+        else:
+            return None
+
+        params = {"group_by": group_by, "page_size": str(page_size)}
+        headers = {"Authorization": f"JWT {token}"}
+
+        session = await self._get_session()
+        try:
+            async with session.get(url, params=params, headers=headers) as response:
+                if response.status == 200:
+                    data = await response.json()
+                    if "results" in data:
+                        return data
+                    return None
+                _LOGGER.debug(
+                    "REST consumption endpoint returned status %s for %s",
+                    response.status, serial
+                )
+                return None
+        except aiohttp.ClientError as err:
+            _LOGGER.debug("REST consumption request failed for %s: %s", serial, err)
+            return None
 
 
 class EnergyAccount:
@@ -196,111 +252,81 @@ class EnergyAccount:
     def __init__(self, api: EonNext, account_number: str):
         self.api = api
         self.account_number = account_number
-    
+        self.meters = []
 
     async def _load_meters(self):
         result = await self.api._graphql_post(
             "getAccountMeterSelector",
-            "query getAccountMeterSelector($accountNumber: String!, $showInactive: Boolean!) {\n  properties(accountNumber: $accountNumber) {\n    ...MeterSelectorPropertyFields\n    __typename\n  }\n}\n\nfragment MeterSelectorPropertyFields on PropertyType {\n  __typename\n  electricityMeterPoints {\n    ...MeterSelectorElectricityMeterPointFields\n    __typename\n  }\n  gasMeterPoints {\n    ...MeterSelectorGasMeterPointFields\n    __typename\n  }\n  id\n  postcode\n}\n\nfragment MeterSelectorElectricityMeterPointFields on ElectricityMeterPointType {\n  __typename\n  id\n  meters(includeInactive: $showInactive) {\n    ...MeterSelectorElectricityMeterFields\n    __typename\n  }\n}\n\nfragment MeterSelectorElectricityMeterFields on ElectricityMeterType {\n  __typename\n  activeTo\n  id\n  registers {\n    id\n    name\n    __typename\n  }\n  serialNumber\n}\n\nfragment MeterSelectorGasMeterPointFields on GasMeterPointType {\n  __typename\n  id\n  meters(includeInactive: $showInactive) {\n    ...MeterSelectorGasMeterFields\n    __typename\n  }\n}\n\nfragment MeterSelectorGasMeterFields on GasMeterType {\n  __typename\n  activeTo\n  id\n  registers {\n    id\n    name\n    __typename\n  }\n  serialNumber\n}\n",
+            "query getAccountMeterSelector($accountNumber: String!, $showInactive: Boolean!) {\n  properties(accountNumber: $accountNumber) {\n    ...MeterSelectorPropertyFields\n    __typename\n  }\n}\n\nfragment MeterSelectorPropertyFields on PropertyType {\n  __typename\n  electricityMeterPoints {\n    ...MeterSelectorElectricityMeterPointFields\n    __typename\n  }\n  gasMeterPoints {\n    ...MeterSelectorGasMeterPointFields\n    __typename\n  }\n  id\n  postcode\n}\n\nfragment MeterSelectorElectricityMeterPointFields on ElectricityMeterPointType {\n  __typename\n  id\n  mpan\n  meters(includeInactive: $showInactive) {\n    ...MeterSelectorElectricityMeterFields\n    __typename\n  }\n}\n\nfragment MeterSelectorElectricityMeterFields on ElectricityMeterType {\n  __typename\n  activeTo\n  id\n  registers {\n    id\n    name\n    __typename\n  }\n  serialNumber\n}\n\nfragment MeterSelectorGasMeterPointFields on GasMeterPointType {\n  __typename\n  id\n  mprn\n  meters(includeInactive: $showInactive) {\n    ...MeterSelectorGasMeterFields\n    __typename\n  }\n}\n\nfragment MeterSelectorGasMeterFields on GasMeterType {\n  __typename\n  activeTo\n  id\n  registers {\n    id\n    name\n    __typename\n  }\n  serialNumber\n}\n",
             {
                 "accountNumber": self.account_number,
                 "showInactive": False
             }
         )
-        
-        if self.api._json_contains_key_chain(result, ["data", "properties"]) == False:
-            raise Exception("Unable to load energy meters for account " + self.account_number)
-        
+
+        if not self.api._json_contains_key_chain(result, ["data", "properties"]):
+            raise EonNextApiError(
+                "Unable to load energy meters for account " + self.account_number
+            )
+
         self.meters = []
-        for property in result['data']['properties']:
-
-            for electricity_point in property['electricityMeterPoints']:
+        for prop in result['data']['properties']:
+            for electricity_point in prop['electricityMeterPoints']:
+                supply_point_id = electricity_point.get('mpan') or electricity_point.get('id', '')
                 for meter_config in electricity_point['meters']:
-                    meter = ElectricityMeter(self, meter_config['id'], meter_config['serialNumber'])
+                    meter = ElectricityMeter(
+                        self,
+                        meter_config['id'],
+                        meter_config['serialNumber'],
+                        supply_point_id,
+                    )
                     self.meters.append(meter)
-            
-            for gas_point in property['gasMeterPoints']:
+
+            for gas_point in prop['gasMeterPoints']:
+                supply_point_id = gas_point.get('mprn') or gas_point.get('id', '')
                 for meter_config in gas_point['meters']:
-                    meter = GasMeter(self, meter_config['id'], meter_config['serialNumber'])
+                    meter = GasMeter(
+                        self,
+                        meter_config['id'],
+                        meter_config['serialNumber'],
+                        supply_point_id,
+                    )
                     self.meters.append(meter)
-
-
 
 
 class EnergyMeter:
 
-    def __init__(self, account: EnergyAccount, meter_id: str, serial: str):
+    def __init__(self, account: EnergyAccount, meter_id: str, serial: str, supply_point_id: str = ""):
         self.account = account
         self.api = account.api
-
-        self.last_updated = None
 
         self.type = METER_TYPE_UNKNOWN
         self.meter_id = meter_id
         self.serial = serial
+        self.supply_point_id = supply_point_id
 
         self.latest_reading = None
         self.latest_reading_date = None
-    
 
     def get_type(self) -> str:
         return self.type
-    
 
     def get_serial(self) -> str:
         return self.serial
-    
-
-    def _should_update(self) -> bool:
-        if self.last_updated == None:
-            return True
-        
-        now = datetime.datetime.now()
-        if now.strftime("%d") != self.last_updated.strftime("%d"):
-            if now.hour >= 7:
-                return True
-        
-        return False
-
 
     def _convert_datetime_str_to_date(self, datetime_str: str) -> datetime.date:
         date_chunks = str(datetime_str.split("T")[0]).split("-")
         return datetime.date(int(date_chunks[0]), int(date_chunks[1]), int(date_chunks[2]))
-    
 
     async def _update(self):
         pass
 
 
-    async def update(self):
-        if self._should_update() == True:
-            await self._update()
-    
-
-    async def has_reading(self) -> bool:
-        await self.update()
-        if self.latest_reading != None:
-            return True
-        return False
-
-
-    async def get_latest_reading(self) -> int:
-        await self.update()
-        return self.latest_reading
-
-
-    async def get_latest_reading_date(self) -> datetime.date:
-        await self.update()
-        return self.latest_reading_date
-
-
-
 class ElectricityMeter(EnergyMeter):
 
-    def __init__(self, account: EnergyAccount, meter_id: str, serial: str):
-        super().__init__(account, meter_id, serial)
+    def __init__(self, account: EnergyAccount, meter_id: str, serial: str, supply_point_id: str = ""):
+        super().__init__(account, meter_id, serial, supply_point_id)
         self.type = METER_TYPE_ELECTRIC
-    
 
     async def _update(self):
         result = await self.api._graphql_post(
@@ -313,23 +339,21 @@ class ElectricityMeter(EnergyMeter):
             }
         )
 
-        if self.api._json_contains_key_chain(result, ["data", "readings"]) == False:
-            raise Exception("Unable to load readings for meter " + self.serial)
+        if not self.api._json_contains_key_chain(result, ["data", "readings"]):
+            _LOGGER.warning("Unable to load readings for meter %s", self.serial)
+            return
 
         readings = result['data']['readings']['edges']
         if len(readings) > 0:
             self.latest_reading = round(float(readings[0]['node']['registers'][0]['value']))
             self.latest_reading_date = self._convert_datetime_str_to_date(readings[0]['node']['readAt'])
-            self.last_updated = datetime.datetime.now()
-
 
 
 class GasMeter(EnergyMeter):
 
-    def __init__(self, account: EnergyAccount, meter_id: str, serial: str):
-        super().__init__(account, meter_id, serial)
+    def __init__(self, account: EnergyAccount, meter_id: str, serial: str, supply_point_id: str = ""):
+        super().__init__(account, meter_id, serial, supply_point_id)
         self.type = METER_TYPE_GAS
-    
 
     async def _update(self):
         result = await self.api._graphql_post(
@@ -342,22 +366,19 @@ class GasMeter(EnergyMeter):
             }
         )
 
-        if self.api._json_contains_key_chain(result, ["data", "readings"]) == False:
-            raise Exception("Unable to load readings for meter " + self.serial)
+        if not self.api._json_contains_key_chain(result, ["data", "readings"]):
+            _LOGGER.warning("Unable to load readings for meter %s", self.serial)
+            return
 
         readings = result['data']['readings']['edges']
         if len(readings) > 0:
             self.latest_reading = round(float(readings[0]['node']['registers'][0]['value']))
             self.latest_reading_date = self._convert_datetime_str_to_date(readings[0]['node']['readAt'])
-            self.last_updated = datetime.datetime.now()
-    
 
-    async def get_latest_reading_kwh(self) -> int:
-        m3 = await self.get_latest_reading()
-        gas_caloric_value = 38
-
-        kwh = m3 * 1.02264
-        kwh = kwh * gas_caloric_value
+    def get_latest_reading_kwh(self, m3_value: float) -> float:
+        """Convert gas m3 reading to kWh."""
+        from .const import GAS_CALORIC_VALUE, GAS_VOLUME_CORRECTION
+        kwh = m3_value * GAS_VOLUME_CORRECTION
+        kwh = kwh * GAS_CALORIC_VALUE
         kwh = kwh / 3.6
-
         return round(kwh)

--- a/custom_components/eon_next/manifest.json
+++ b/custom_components/eon_next/manifest.json
@@ -4,10 +4,10 @@
     "codeowners": ["@madmachinations"],
     "config_flow": true,
     "dependencies": [],
-    "documentation": "https://gitlab.com/home-assistant-components/eon-next/-/blob/main/README.md",
+    "documentation": "https://github.com/monsagri/eon-next-v2",
     "integration_type": "hub",
     "iot_class": "cloud_polling",
-    "issue_tracker": "https://github.com/madmachinations/eon-next/issues",
+    "issue_tracker": "https://github.com/monsagri/eon-next-v2/issues",
     "requirements": [],
-    "version": "0.1.0"
+    "version": "1.0.0"
   }

--- a/custom_components/eon_next/manifest.json
+++ b/custom_components/eon_next/manifest.json
@@ -5,9 +5,10 @@
     "config_flow": true,
     "dependencies": [],
     "documentation": "https://github.com/monsagri/eon-next-v2",
+    "homeassistant": "2024.4.0",
     "integration_type": "hub",
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/monsagri/eon-next-v2/issues",
     "requirements": [],
-    "version": "1.0.0"
+    "version": "1.1.0"
   }

--- a/custom_components/eon_next/models.py
+++ b/custom_components/eon_next/models.py
@@ -1,0 +1,21 @@
+"""Data models for the Eon Next integration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from homeassistant.config_entries import ConfigEntry
+
+from .coordinator import EonNextCoordinator
+from .eonnext import EonNext
+
+
+@dataclass(slots=True)
+class EonNextRuntimeData:
+    """Runtime data for an Eon Next config entry."""
+
+    api: EonNext
+    coordinator: EonNextCoordinator
+
+
+EonNextConfigEntry = ConfigEntry[EonNextRuntimeData]

--- a/custom_components/eon_next/sensor.py
+++ b/custom_components/eon_next/sensor.py
@@ -14,9 +14,9 @@ from homeassistant.const import UnitOfEnergy, UnitOfVolume
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
 
-from . import EonNextConfigEntry
 from .coordinator import ev_data_key
 from .eonnext import METER_TYPE_ELECTRIC, METER_TYPE_GAS
+from .models import EonNextConfigEntry
 
 
 async def async_setup_entry(hass, config_entry: EonNextConfigEntry, async_add_entities):

--- a/custom_components/eon_next/sensor.py
+++ b/custom_components/eon_next/sensor.py
@@ -1,40 +1,34 @@
 #!/usr/bin/env python3
 """Sensor platform for the Eon Next integration."""
 
-import logging
+from __future__ import annotations
+
+from typing import Any
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
     SensorStateClass,
 )
-
-from homeassistant.const import (
-    UnitOfEnergy,
-    UnitOfVolume,
-)
-
+from homeassistant.const import UnitOfEnergy, UnitOfVolume
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util import dt as dt_util
 
-from .const import DOMAIN
-from .eonnext import METER_TYPE_GAS, METER_TYPE_ELECTRIC
+from . import EonNextConfigEntry
+from .coordinator import ev_data_key
+from .eonnext import METER_TYPE_ELECTRIC, METER_TYPE_GAS
 
-_LOGGER = logging.getLogger(__name__)
 
-
-async def async_setup_entry(hass, config_entry, async_add_entities):
+async def async_setup_entry(hass, config_entry: EonNextConfigEntry, async_add_entities):
     """Set up sensors from a config entry."""
-    entry_data = hass.data[DOMAIN][config_entry.entry_id]
-    coordinator = entry_data["coordinator"]
-    api = entry_data["api"]
+    del hass
 
-    entities = []
+    coordinator = config_entry.runtime_data.coordinator
+    api = config_entry.runtime_data.api
+
+    entities: list[SensorEntity] = []
     for account in api.accounts:
         for meter in account.meters:
-            serial = meter.serial
-            if serial not in coordinator.data:
-                continue
-
             entities.append(LatestReadingDateSensor(coordinator, meter))
 
             if meter.type == METER_TYPE_ELECTRIC:
@@ -44,10 +38,14 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                 entities.append(LatestGasCubicMetersSensor(coordinator, meter))
                 entities.append(LatestGasKwhSensor(coordinator, meter))
 
-            # Add daily consumption sensor if REST data is available
-            meter_data = coordinator.data.get(serial, {})
-            if meter_data.get("daily_consumption") is not None:
-                entities.append(DailyConsumptionSensor(coordinator, meter))
+            entities.append(DailyConsumptionSensor(coordinator, meter))
+
+        for charger in account.ev_chargers:
+            entities.append(SmartChargingScheduleSensor(coordinator, charger))
+            entities.append(NextChargeStartSensor(coordinator, charger))
+            entities.append(NextChargeEndSensor(coordinator, charger))
+            entities.append(NextChargeStartSlot2Sensor(coordinator, charger))
+            entities.append(NextChargeEndSlot2Sensor(coordinator, charger))
 
     async_add_entities(entities)
 
@@ -55,14 +53,14 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class EonNextSensorBase(CoordinatorEntity, SensorEntity):
     """Base class for Eon Next sensors."""
 
-    def __init__(self, coordinator, meter):
+    def __init__(self, coordinator, data_key: str):
         super().__init__(coordinator)
-        self._meter_serial = meter.serial
+        self._data_key = data_key
 
     @property
-    def _meter_data(self) -> dict | None:
-        if self.coordinator.data and self._meter_serial in self.coordinator.data:
-            return self.coordinator.data[self._meter_serial]
+    def _meter_data(self) -> dict[str, Any] | None:
+        if self.coordinator.data and self._data_key in self.coordinator.data:
+            return self.coordinator.data[self._data_key]
         return None
 
     @property
@@ -74,7 +72,7 @@ class LatestReadingDateSensor(EonNextSensorBase):
     """Date of latest meter reading."""
 
     def __init__(self, coordinator, meter):
-        super().__init__(coordinator, meter)
+        super().__init__(coordinator, meter.serial)
         self._attr_name = f"{meter.serial} Reading Date"
         self._attr_device_class = SensorDeviceClass.DATE
         self._attr_icon = "mdi:calendar"
@@ -83,14 +81,14 @@ class LatestReadingDateSensor(EonNextSensorBase):
     @property
     def native_value(self):
         data = self._meter_data
-        return data["latest_reading_date"] if data else None
+        return data.get("latest_reading_date") if data else None
 
 
 class LatestElectricKwhSensor(EonNextSensorBase):
     """Latest electricity meter reading."""
 
     def __init__(self, coordinator, meter):
-        super().__init__(coordinator, meter)
+        super().__init__(coordinator, meter.serial)
         self._attr_name = f"{meter.serial} Electricity"
         self._attr_device_class = SensorDeviceClass.ENERGY
         self._attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
@@ -101,14 +99,14 @@ class LatestElectricKwhSensor(EonNextSensorBase):
     @property
     def native_value(self):
         data = self._meter_data
-        return data["latest_reading"] if data else None
+        return data.get("latest_reading") if data else None
 
 
 class LatestGasKwhSensor(EonNextSensorBase):
     """Latest gas meter reading in kWh."""
 
     def __init__(self, coordinator, meter):
-        super().__init__(coordinator, meter)
+        super().__init__(coordinator, meter.serial)
         self._attr_name = f"{meter.serial} Gas kWh"
         self._attr_device_class = SensorDeviceClass.ENERGY
         self._attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
@@ -126,7 +124,7 @@ class LatestGasCubicMetersSensor(EonNextSensorBase):
     """Latest gas meter reading in cubic meters."""
 
     def __init__(self, coordinator, meter):
-        super().__init__(coordinator, meter)
+        super().__init__(coordinator, meter.serial)
         self._attr_name = f"{meter.serial} Gas"
         self._attr_device_class = SensorDeviceClass.GAS
         self._attr_native_unit_of_measurement = UnitOfVolume.CUBIC_METERS
@@ -137,18 +135,18 @@ class LatestGasCubicMetersSensor(EonNextSensorBase):
     @property
     def native_value(self):
         data = self._meter_data
-        return data["latest_reading"] if data else None
+        return data.get("latest_reading") if data else None
 
 
 class DailyConsumptionSensor(EonNextSensorBase):
     """Daily energy consumption from smart meter data."""
 
     def __init__(self, coordinator, meter):
-        super().__init__(coordinator, meter)
+        super().__init__(coordinator, meter.serial)
         self._attr_name = f"{meter.serial} Daily Consumption"
         self._attr_device_class = SensorDeviceClass.ENERGY
         self._attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
-        self._attr_state_class = SensorStateClass.TOTAL_INCREASING
+        self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_icon = "mdi:lightning-bolt"
         self._attr_unique_id = f"{meter.serial}__daily_consumption"
 
@@ -156,3 +154,101 @@ class DailyConsumptionSensor(EonNextSensorBase):
     def native_value(self):
         data = self._meter_data
         return data.get("daily_consumption") if data else None
+
+
+class SmartChargingScheduleSensor(EonNextSensorBase):
+    """Smart charging schedule status."""
+
+    def __init__(self, coordinator, charger):
+        super().__init__(coordinator, ev_data_key(charger.device_id))
+        self._attr_name = f"{charger.serial} Smart Charging Schedule"
+        self._attr_icon = "mdi:ev-station"
+        self._attr_unique_id = f"{charger.device_id}__smart_charging_schedule"
+
+    @property
+    def native_value(self):
+        data = self._meter_data
+        if not data:
+            return None
+
+        schedule = data.get("schedule", [])
+        if schedule:
+            return "Active"
+        return "No Schedule"
+
+    @property
+    def extra_state_attributes(self):
+        data = self._meter_data or {}
+        return {"schedule": data.get("schedule", [])}
+
+
+class NextChargeStartSensor(EonNextSensorBase):
+    """Start time of next EV charge slot."""
+
+    def __init__(self, coordinator, charger):
+        super().__init__(coordinator, ev_data_key(charger.device_id))
+        self._attr_name = f"{charger.serial} Next Charge Start"
+        self._attr_device_class = SensorDeviceClass.TIMESTAMP
+        self._attr_icon = "mdi:clock-start"
+        self._attr_unique_id = f"{charger.device_id}__next_charge_start"
+
+    @property
+    def native_value(self):
+        data = self._meter_data
+        if not data:
+            return None
+        return dt_util.parse_datetime(data.get("next_charge_start"))
+
+
+class NextChargeEndSensor(EonNextSensorBase):
+    """End time of next EV charge slot."""
+
+    def __init__(self, coordinator, charger):
+        super().__init__(coordinator, ev_data_key(charger.device_id))
+        self._attr_name = f"{charger.serial} Next Charge End"
+        self._attr_device_class = SensorDeviceClass.TIMESTAMP
+        self._attr_icon = "mdi:clock-end"
+        self._attr_unique_id = f"{charger.device_id}__next_charge_end"
+
+    @property
+    def native_value(self):
+        data = self._meter_data
+        if not data:
+            return None
+        return dt_util.parse_datetime(data.get("next_charge_end"))
+
+
+class NextChargeStartSlot2Sensor(EonNextSensorBase):
+    """Start time of the second EV charge slot."""
+
+    def __init__(self, coordinator, charger):
+        super().__init__(coordinator, ev_data_key(charger.device_id))
+        self._attr_name = f"{charger.serial} Next Charge Start 2"
+        self._attr_device_class = SensorDeviceClass.TIMESTAMP
+        self._attr_icon = "mdi:clock-start"
+        self._attr_unique_id = f"{charger.device_id}__next_charge_start_2"
+
+    @property
+    def native_value(self):
+        data = self._meter_data
+        if not data:
+            return None
+        return dt_util.parse_datetime(data.get("next_charge_start_2"))
+
+
+class NextChargeEndSlot2Sensor(EonNextSensorBase):
+    """End time of the second EV charge slot."""
+
+    def __init__(self, coordinator, charger):
+        super().__init__(coordinator, ev_data_key(charger.device_id))
+        self._attr_name = f"{charger.serial} Next Charge End 2"
+        self._attr_device_class = SensorDeviceClass.TIMESTAMP
+        self._attr_icon = "mdi:clock-end"
+        self._attr_unique_id = f"{charger.device_id}__next_charge_end_2"
+
+    @property
+    def native_value(self):
+        data = self._meter_data
+        if not data:
+            return None
+        return dt_util.parse_datetime(data.get("next_charge_end_2"))

--- a/custom_components/eon_next/strings.json
+++ b/custom_components/eon_next/strings.json
@@ -1,10 +1,21 @@
 {
     "config": {
+        "abort": {
+            "reauth_successful": "Re-authentication was successful"
+        },
         "error": {
             "invalid_auth": "Authentication failed",
             "unknown": "An unexpected error occurred"
         },
         "step": {
+            "reauth_confirm": {
+                "data": {
+                    "email": "Email address",
+                    "password": "Password"
+                },
+                "description": "Your login is no longer valid. Re-enter your credentials to reconnect.",
+                "title": "Reauthenticate Eon Next"
+            },
             "user": {
                 "data": {
                     "email": "Email address",

--- a/custom_components/eon_next/strings.json
+++ b/custom_components/eon_next/strings.json
@@ -1,12 +1,13 @@
 {
     "config": {
         "error": {
-            "invalid_auth": "Authentication failed"
+            "invalid_auth": "Authentication failed",
+            "unknown": "An unexpected error occurred"
         },
         "step": {
             "user": {
                 "data": {
-                    "email": "Email addresss",
+                    "email": "Email address",
                     "password": "Password"
                 },
                 "description": "Login to your Eon Next account.",

--- a/custom_components/eon_next/translations/en.json
+++ b/custom_components/eon_next/translations/en.json
@@ -1,10 +1,21 @@
 {
     "config": {
+        "abort": {
+            "reauth_successful": "Re-authentication was successful"
+        },
         "error": {
             "invalid_auth": "Authentication failed",
             "unknown": "An unexpected error occurred"
         },
         "step": {
+            "reauth_confirm": {
+                "data": {
+                    "email": "Email address",
+                    "password": "Password"
+                },
+                "description": "Your login is no longer valid. Re-enter your credentials to reconnect.",
+                "title": "Reauthenticate Eon Next"
+            },
             "user": {
                 "data": {
                     "email": "Email address",

--- a/custom_components/eon_next/translations/en.json
+++ b/custom_components/eon_next/translations/en.json
@@ -1,12 +1,13 @@
 {
     "config": {
         "error": {
-            "invalid_auth": "Authentication failed"
+            "invalid_auth": "Authentication failed",
+            "unknown": "An unexpected error occurred"
         },
         "step": {
             "user": {
                 "data": {
-                    "email": "Email addresss",
+                    "email": "Email address",
                     "password": "Password"
                 },
                 "description": "Login to your Eon Next account.",

--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,6 @@
 {
     "name": "Eon Next Integration",
-    "country": ["GB"]
+    "country": ["GB"],
+    "homeassistant": "2024.4.0",
+    "render_readme": true
   }

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,8 @@
+{
+  "include": ["custom_components"],
+  "exclude": ["**/__pycache__", ".git", ".venv", ".venv39"],
+  "venvPath": ".",
+  "venv": ".venv",
+  "pythonVersion": "3.13",
+  "typeCheckingMode": "basic"
+}


### PR DESCRIPTION
## Summary

This PR modernizes the E.ON Next integration for current Home Assistant patterns, adds re-auth support, improves data resilience, and prepares the repo for HACS-friendly releases.

## What Changed

- Added Home Assistant re-auth flow (`async_step_reauth` + `async_step_reauth_confirm`) in config flow.
- Switched auth failure handling in the coordinator to raise `ConfigEntryAuthFailed`, so HA can trigger built-in re-auth UX.
- Migrated runtime state storage from `hass.data` to `entry.runtime_data`.
- Added typed runtime model in `custom_components/eon_next/models.py`.
- Improved consumption handling with fallback from REST endpoint to GraphQL `consumptionDataByMpxn`.
- Added EV smart charging support (device discovery + schedule sensors).
- Refined coordinator and sensor structure around `DataUpdateCoordinator` data keys.
- Updated integration metadata for HACS/HA compatibility:
  - `manifest.json` version bump and HA minimum version.
  - `hacs.json` metadata updates.

## Documentation

- Rewrote README to focus on project overview and HACS-first installation.
- Moved maintainer/release process into `DEVELOPMENT.md` (including tag/release workflow).

## Validation

- `python3 -m compileall custom_components/eon_next` completed successfully.

## Notes

- This PR intentionally avoids tariff/saving-session feature work and focuses on stability, re-auth, runtime-data migration, and HACS readiness.
